### PR TITLE
FIX: Update image source in README to use 'master' branch instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/acsenrafilho/dti-template-creator/refs/heads/main/docs/assets/repo-slogan.png" width=700>
+<img src="https://raw.githubusercontent.com/acsenrafilho/dti-template-creator/refs/heads/master/docs/assets/repo-slogan.png" width=700>
 
 
 


### PR DESCRIPTION
This pull request updates the `README.md` file to fix a broken image link by replacing the branch name `main` with `master`.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated the image source URL to use the `master` branch instead of `main`, ensuring the image displays correctly.…'main'